### PR TITLE
[fix] navigate back using phone back button

### DIFF
--- a/lib/Views/notes.dart
+++ b/lib/Views/notes.dart
@@ -22,6 +22,7 @@ class _AllNotesState extends State<AllNotes> {
    });
     super.initState();
   }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -35,13 +36,9 @@ class _AllNotesState extends State<AllNotes> {
       appBar: AppBar(
         title: const Text("Notes"),
       ),
-      body: BlocConsumer<NoteBloc, NoteState>(
+      body: BlocBuilder<NoteBloc, NoteState>(
 
-        listener: (context, state) {
-          if(state is GetNoteByIdState){
-            Navigator.push(context, MaterialPageRoute(builder: (context)=> const UpdateNote()));
-          }
-        },
+        buildWhen: (previousState, currentState) =>  currentState is LoadedState,
 
         builder: (context, state) {
           if (state is LoadedState) {
@@ -55,6 +52,7 @@ class _AllNotesState extends State<AllNotes> {
                   return InkWell(
                     onTap: (){
                       context.read<NoteBloc>().add(GetNoteByIdEvent(state.allNotes[index].noteId!));
+                       Navigator.push(context, MaterialPageRoute(builder: (context)=> const UpdateNote()));
                     },
                     child: Container(
                       margin: const EdgeInsets.all(8),


### PR DESCRIPTION
The issue you're facing with BlocConsumer not rebuilding the UI after navigating back from the UpdateNote screen using the phone's back button is likely due to how Flutter manages widget state

## The Problem:
- When you use Navigator.push to navigate to the UpdateNote screen, a new widget tree is created for that screen.
- When you press the back button, you're popping the UpdateNote screen from the navigation stack, but the original BlocConsumer widget itself isn't rebuilt.
- Since the BlocConsumer widget instance persists, its internal state (which tracks the previously emitted NoteState) remains unchanged.
## Solution : Utilize buildWhen with BlocBuilder

The BlocBuilder widget provides a buildWhen parameter that allows you to control when the builder function is called. You can use this to tell BlocBuilder to rebuild only when the specific NoteState